### PR TITLE
TRIVIAL: fix github docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ jobs:
 
 ## Restricting who can call the action
 
-It's possible to use `author_association` field of a comment to restrict who can call the action and skip the rebase for others. Simply add the following expression to the `if` statement in your workflow file: `github.event.comment.author_association == 'MEMBER'`. See [documentation](https://developer.github.com/v4/enum/commentauthorassociation/) for a list of all available values of `author_association`.
+It's possible to use `author_association` field of a comment to restrict who can call the action and skip the rebase for others. Simply add the following expression to the `if` statement in your workflow file: `github.event.comment.author_association == 'MEMBER'`. See [documentation](https://docs.github.com/v4/enum/commentauthorassociation/) for a list of all available values of `author_association`.


### PR DESCRIPTION
 * the old URL is deprecated, and currently suggests to use the new link
   as a primary docs source