### PR TITLE
TRIVIAL - override for CVE 2022 24765

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,6 +79,9 @@ USER_TOKEN=${USER_LOGIN//-/_}_TOKEN
 UNTRIMMED_COMMITTER_TOKEN=${!USER_TOKEN:-$GITHUB_TOKEN}
 COMMITTER_TOKEN="$(echo -e "${UNTRIMMED_COMMITTER_TOKEN}" | tr -d '[:space:]')"
 
+#workaround for CVE-2022-24765 until git 2.35.2 is in APK
+git config --global --add safe.directory /github/workspace
+
 git remote set-url origin https://x-access-token:$COMMITTER_TOKEN@github.com/$GITHUB_REPOSITORY.git
 git config --global user.email "$USER_EMAIL"
 git config --global user.name "$USER_NAME"


### PR DESCRIPTION
This is override of git until git 2.35.2 is available via APK